### PR TITLE
docs: Multi-scope regions spec (v0.3.0) and issue template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Configuration variables:
 * **region_code**: The location ID you want to collect values from. You can find it by analyzing the network traffic of the webpage as shown in the following.
 * **scan_interval** (optional): How often new updates should be fetched. In minutes, default 5 minutes same as the official web app.
 
+**Planned (v0.3.0):** Optional additional regions via a `scope` list (backward compatible). Design spec: [doc/SCOPE_SPEC.md](doc/SCOPE_SPEC.md). Discussion: [issue #4](https://github.com/dannerph/homeassistant-eon-energiemonitor/issues/4).
+
 ![how to find region code](doc/regionCode.png "Network traffic analysis ")
 
 Works best with the [power-distribution-card](https://github.com/JonahKr/power-distribution-card) by [JonahKr](https://github.com/JonahKr).

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Configuration variables:
 * **region_code**: The location ID you want to collect values from. You can find it by analyzing the network traffic of the webpage as shown in the following.
 * **scan_interval** (optional): How often new updates should be fetched. In minutes, default 5 minutes same as the official web app.
 
-**Planned (v0.3.0):** Optional additional regions via a `scope` list (backward compatible). Design spec: [doc/SCOPE_SPEC.md](doc/SCOPE_SPEC.md). Discussion: [issue #4](https://github.com/dannerph/homeassistant-eon-energiemonitor/issues/4).
-
 ![how to find region code](doc/regionCode.png "Network traffic analysis ")
 
 Works best with the [power-distribution-card](https://github.com/JonahKr/power-distribution-card) by [JonahKr](https://github.com/JonahKr).

--- a/doc/SCOPE_ISSUE.md
+++ b/doc/SCOPE_ISSUE.md
@@ -1,0 +1,119 @@
+# GitHub issue (upstream)
+
+| | |
+|---|---|
+| **Title** | Feature: Multiple EON regions via optional `scope` list (v0.3.0, backward compatible) |
+| **Repository** | `dannerph/homeassistant-eon-energiemonitor` |
+| **Issue** | [#4](https://github.com/dannerph/homeassistant-eon-energiemonitor/issues/4) |
+| **Labels** | `enhancement` |
+| **Spec** | [SCOPE_SPEC.md](SCOPE_SPEC.md) |
+| **Regenerate** | `python3 scripts/generate-scope-issue.py` |
+
+> Auto-generated from `doc/scope-issue.meta.yaml` and `doc/templates/scope-issue.en.md`.  
+> Edit those sources, then run the script. Use **Issue body** below for GitHub (or use `--body-file doc/templates/scope-issue.en.md`).
+
+---
+
+## Issue body (copy from here)
+
+## Summary
+
+The EON Energiemonitor API exposes many regions at different administrative levels (municipality, district, regierungsbezirk, grid area, etc.). Today the integration supports **one** `region_code` only.
+
+I would like **optional additional regions** in the same integration instance, without breaking existing setups (entity IDs, automations, Lovelace).
+
+This is a **design proposal** for a future **v0.3.0** — not implemented yet. Feedback welcome before any PR.
+
+Detailed draft spec: `doc/SCOPE_SPEC.md` in the integration repository (see linked PR or default branch).
+
+## Motivation
+
+- Users may want to compare e.g. their **municipality** and the enclosing **district** (both have separate `regionCode` values in the API).
+- The API also lists other levels (Teilnetz, Bundesland, …); a **generic** config is preferable to hard-coding fixed administrative levels.
+- Existing installations should keep `sensor.eon_energiemonitor_*` unchanged.
+
+## Proposed configuration
+
+Keep today’s required `region_code` as the **legacy slot** (unprefixed entities). Add an optional list `scope` for further regions:
+
+```yaml
+eon-energiemonitor:
+  region_code: "01234567"   # legacy / primary region
+  scan_interval: 5
+  scope:
+    - region_code: "01234"
+      alias: landkreis
+      # scan_interval: 10   # optional per-scope override
+```
+
+| Key | Meaning |
+|-----|---------|
+| `region_code` | Unchanged: drives all current entity names |
+| `scan_interval` | Global default (minutes) |
+| `scope` | Optional; omit = current behaviour |
+| `scope[].region_code` | Numeric EON `regionCode` |
+| `scope[].alias` | User-defined prefix for entity / `unique_id` names |
+| `scope[].scan_interval` | Optional override for that entry only |
+
+Codes can be resolved via `region-data?regionUrlKey=<slug>` or `region-data?tenantId=<id>` (public API). See also region list documentation in related PRs/docs.
+
+## Entity naming
+
+| Role | Pattern |
+|------|---------|
+| Legacy | `sensor.eon_energiemonitor_{metric}` / `unique_id` `eon_energy_{metric}` |
+| Scope | `sensor.eon_energiemonitor_{alias}_{metric}` / `eon_energy_{alias}_{metric}` |
+
+Each scope should get the **same sensor types** the API provides for that region (including `status` and `region` with `dashboard_url`), not a reduced subset.
+
+Examples:
+
+- `sensor.eon_energiemonitor_autarky` (legacy, unchanged)
+- `sensor.eon_energiemonitor_landkreis_autarky`
+- `sensor.eon_energiemonitor_landkreis_status`
+
+## Validation
+
+- `alias`: `^[a-z0-9_]+$`, unique within `scope`, duplicates rejected at setup
+- Block **reserved** aliases that collide with legacy metric names: `status`, `region`, `autarky`, `secondaryinfeed`, `energymix`, `bio`, `solar`, `wind`, `water`, `others`, `domestic`, `public`, `industrial`
+- No hard limit on the number of `scope` entries (practical limit: API load)
+
+## Runtime / repairs
+
+- Missing API value for a metric → sensor exists, state **`unavailable`** (HA standard)
+- Invalid / unknown `region_code` for a **scope** entry → repair issue **per `alias`**; legacy region continues if its API calls succeed
+- Update failures for a scope → separate repair per `alias`
+
+## Non-goals (initial version)
+
+- Replacing `region_code` with a `regions`-only config (breaking change)
+- Config flow / UI (YAML only, as today)
+- Auto-detecting administrative level from the API (user chooses `alias`)
+
+## Suggested version
+
+**0.3.0** after any pending v0.2.x work is merged.
+
+## Implementation
+
+Happy to submit a PR if this direction is acceptable.
+---
+
+## Recreate or update on GitHub
+
+```bash
+gh issue view 4 --repo dannerph/homeassistant-eon-energiemonitor
+
+# New issue:
+gh issue create --repo dannerph/homeassistant-eon-energiemonitor \
+  --title 'Feature: Multiple EON regions via optional `scope` list (v0.3.0, backward compatible)' \
+  --body-file doc/templates/scope-issue.en.md \
+  --label enhancement
+
+# Update existing issue #4:
+gh issue edit 4 --repo dannerph/homeassistant-eon-energiemonitor \
+  --title 'Feature: Multiple EON regions via optional `scope` list (v0.3.0, backward compatible)' \
+  --body-file doc/templates/scope-issue.en.md
+```
+
+After creating a new issue, set `issue_number` in `doc/scope-issue.meta.yaml` and re-run this script.

--- a/doc/SCOPE_SPEC.md
+++ b/doc/SCOPE_SPEC.md
@@ -1,0 +1,113 @@
+# Multi-scope regions (planned v0.3.0)
+
+Specification for supporting several EON regions in one Home Assistant integration while keeping existing installations unchanged.
+
+**Status:** Spec only — not implemented yet.
+
+| | |
+|---|---|
+| **Upstream issue** | [dannerph/homeassistant-eon-energiemonitor#4](https://github.com/dannerph/homeassistant-eon-energiemonitor/issues/4) |
+| **Issue text (regenerate)** | `python3 scripts/generate-scope-issue.py` → [SCOPE_ISSUE.md](SCOPE_ISSUE.md) |
+
+## Goals
+
+- **Backward compatible:** Existing configs with only `region_code` keep the same entity IDs (`sensor.eon_energiemonitor_*`, `unique_id` `eon_energy_*`).
+- **Generic:** Any administrative level the API offers (municipality, district, regierungsbezirk, …) via user-defined `alias`, not hard-coded “Gemeinde + Landkreis”.
+- **Parity:** Each scope gets the same sensor types the API provides for that region, plus `status` and `region` sensors with `dashboard_url`.
+
+## Configuration
+
+```yaml
+eon-energiemonitor:
+  region_code: "01234567"   # legacy slot (your primary region)
+  scan_interval: 5          # default for all regions
+  scope:
+    - region_code: "01234"
+      alias: landkreis
+      # scan_interval: 10   # optional override for this scope only
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `region_code` | yes | Legacy region; drives unprefixed entities |
+| `scan_interval` | no (default 5) | Global poll interval (minutes) |
+| `scope` | no | Extra regions; empty or omitted = current behaviour |
+| `scope[].region_code` | yes per entry | Numeric EON `regionCode` |
+| `scope[].alias` | yes per entry | Prefix for entity / `unique_id` names |
+| `scope[].scan_interval` | no | Overrides global interval for this entry only |
+
+Example (municipality + enclosing district):
+
+| Role | `region_code` | `alias` | Dashboard slug (from API `regionUrlKey`) |
+|------|---------------|---------|------------------------------------------|
+| Legacy | `01234567` | — | `gemeinde-beispiel` |
+| Scope | `01234` | `landkreis` | `landkreis-beispiel` |
+
+Resolve real codes via [REGIONEN.md](REGIONEN.md) or `region-data?regionUrlKey=<slug>`.
+
+## Entity naming
+
+| Role | `entity_id` pattern | `unique_id` pattern |
+|------|---------------------|---------------------|
+| Legacy | `sensor.eon_energiemonitor_{metric}` | `eon_energy_{metric}` |
+| Scope | `sensor.eon_energiemonitor_{alias}_{metric}` | `eon_energy_{alias}_{metric}` |
+
+`{metric}` includes: `status`, `region`, `autarky`, `energymix`, `secondaryinfeed`, and all consumption/generation keys exposed today (same set as legacy, driven by API payload per region).
+
+**Examples**
+
+- Legacy: `sensor.eon_energiemonitor_autarky`
+- Scope: `sensor.eon_energiemonitor_landkreis_autarky`, `sensor.eon_energiemonitor_landkreis_status`
+
+## Validation
+
+| Rule | On violation |
+|------|----------------|
+| `region_code` / `scope[].region_code` non-empty, numeric | `ConfigError` at setup |
+| `alias` matches `^[a-z0-9_]+$` | `ConfigError` at setup |
+| `alias` unique within `scope` | `ConfigError` at setup |
+| `alias` not in **reserved** list | `ConfigError` at setup |
+| No limit on number of `scope` entries | — |
+
+**Reserved `alias` values** (collision with legacy metric names):  
+`status`, `region`, `autarky`, `secondaryinfeed`, `energymix`, `bio`, `solar`, `wind`, `water`, `others`, `domestic`, `public`, `industrial`.
+
+## Runtime behaviour
+
+- One coordinator (or equivalent) per configured region; legacy and scopes polled on their intervals.
+- API returns no value for a metric → sensor exists, state **`unavailable`** (HA standard).
+- HTTP 404 / invalid `region_code` for a scope → scope sensors `unavailable`; **Repair issue per `alias`** (`region_not_found_{alias}` or similar). Legacy region unaffected if its API calls succeed.
+- Update failures for a scope → **Repair issue per `alias`**; legacy issues unchanged when only a scope fails.
+
+## Repairs
+
+| Case | Behaviour |
+|------|-----------|
+| Legacy `region_code` not found | Existing `region_not_found` issue |
+| Scope `region_code` not found | New issue, placeholders include `alias` and `region_code` |
+| Scope update failed (network, parse, …) | New issue per `alias` |
+| Legacy OK, scope failing | No regression on legacy entities |
+
+## Non-goals (v0.3.0)
+
+- Replacing `region_code` with a single `regions:` list only (would break existing YAML).
+- Config UI / config flow (YAML only, as today).
+- Auto-discovery of administrative level from API (only user `alias`).
+
+## Implementation notes (for developers)
+
+- Refactor `hass.data[DOMAIN]` to hold legacy coordinator + map `alias → coordinator`.
+- `async_setup_platform`: register legacy sensors first (unchanged classes/IDs), then loop `scope` and register prefixed sensors.
+- Issue registry IDs must be unique per `alias`.
+- Document in README + `doc/API.md`; example under `doc/examples/`.
+- Version bump: **0.3.0** in `manifest.json` when implemented.
+
+## Open questions (none blocking spec)
+
+- Exact translation keys / repair issue IDs (to be aligned with `strings.json` at implementation).
+
+## References
+
+- Region list: [REGIONEN.md](REGIONEN.md)
+- API fields: [API.md](API.md)
+- GitHub issue template: [scope-issue.meta.yaml](scope-issue.meta.yaml), [templates/scope-issue.en.md](templates/scope-issue.en.md)

--- a/doc/scope-issue.meta.yaml
+++ b/doc/scope-issue.meta.yaml
@@ -1,0 +1,6 @@
+# Metadata for regenerating the upstream GitHub issue (see scripts/generate-scope-issue.py)
+upstream_repo: dannerph/homeassistant-eon-energiemonitor
+issue_number: 4
+title: "Feature: Multiple EON regions via optional `scope` list (v0.3.0, backward compatible)"
+labels:
+  - enhancement

--- a/doc/templates/scope-issue.en.md
+++ b/doc/templates/scope-issue.en.md
@@ -1,0 +1,81 @@
+## Summary
+
+The EON Energiemonitor API exposes many regions at different administrative levels (municipality, district, regierungsbezirk, grid area, etc.). Today the integration supports **one** `region_code` only.
+
+I would like **optional additional regions** in the same integration instance, without breaking existing setups (entity IDs, automations, Lovelace).
+
+This is a **design proposal** for a future **v0.3.0** — not implemented yet. Feedback welcome before any PR.
+
+Detailed draft spec: `doc/SCOPE_SPEC.md` in the integration repository (see linked PR or default branch).
+
+## Motivation
+
+- Users may want to compare e.g. their **municipality** and the enclosing **district** (both have separate `regionCode` values in the API).
+- The API also lists other levels (Teilnetz, Bundesland, …); a **generic** config is preferable to hard-coding fixed administrative levels.
+- Existing installations should keep `sensor.eon_energiemonitor_*` unchanged.
+
+## Proposed configuration
+
+Keep today’s required `region_code` as the **legacy slot** (unprefixed entities). Add an optional list `scope` for further regions:
+
+```yaml
+eon-energiemonitor:
+  region_code: "01234567"   # legacy / primary region
+  scan_interval: 5
+  scope:
+    - region_code: "01234"
+      alias: landkreis
+      # scan_interval: 10   # optional per-scope override
+```
+
+| Key | Meaning |
+|-----|---------|
+| `region_code` | Unchanged: drives all current entity names |
+| `scan_interval` | Global default (minutes) |
+| `scope` | Optional; omit = current behaviour |
+| `scope[].region_code` | Numeric EON `regionCode` |
+| `scope[].alias` | User-defined prefix for entity / `unique_id` names |
+| `scope[].scan_interval` | Optional override for that entry only |
+
+Codes can be resolved via `region-data?regionUrlKey=<slug>` or `region-data?tenantId=<id>` (public API). See also region list documentation in related PRs/docs.
+
+## Entity naming
+
+| Role | Pattern |
+|------|---------|
+| Legacy | `sensor.eon_energiemonitor_{metric}` / `unique_id` `eon_energy_{metric}` |
+| Scope | `sensor.eon_energiemonitor_{alias}_{metric}` / `eon_energy_{alias}_{metric}` |
+
+Each scope should get the **same sensor types** the API provides for that region (including `status` and `region` with `dashboard_url`), not a reduced subset.
+
+Examples:
+
+- `sensor.eon_energiemonitor_autarky` (legacy, unchanged)
+- `sensor.eon_energiemonitor_landkreis_autarky`
+- `sensor.eon_energiemonitor_landkreis_status`
+
+## Validation
+
+- `alias`: `^[a-z0-9_]+$`, unique within `scope`, duplicates rejected at setup
+- Block **reserved** aliases that collide with legacy metric names: `status`, `region`, `autarky`, `secondaryinfeed`, `energymix`, `bio`, `solar`, `wind`, `water`, `others`, `domestic`, `public`, `industrial`
+- No hard limit on the number of `scope` entries (practical limit: API load)
+
+## Runtime / repairs
+
+- Missing API value for a metric → sensor exists, state **`unavailable`** (HA standard)
+- Invalid / unknown `region_code` for a **scope** entry → repair issue **per `alias`**; legacy region continues if its API calls succeed
+- Update failures for a scope → separate repair per `alias`
+
+## Non-goals (initial version)
+
+- Replacing `region_code` with a `regions`-only config (breaking change)
+- Config flow / UI (YAML only, as today)
+- Auto-detecting administrative level from the API (user chooses `alias`)
+
+## Suggested version
+
+**0.3.0** after any pending v0.2.x work is merged.
+
+## Implementation
+
+Happy to submit a PR if this direction is acceptable.

--- a/scripts/generate-scope-issue.py
+++ b/scripts/generate-scope-issue.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Generate doc/SCOPE_ISSUE.md from template + metadata (for GitHub issue regeneration)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+META_PATH = REPO_ROOT / "doc" / "scope-issue.meta.yaml"
+TEMPLATE_PATH = REPO_ROOT / "doc" / "templates" / "scope-issue.en.md"
+OUT_PATH = REPO_ROOT / "doc" / "SCOPE_ISSUE.md"
+
+
+def load_meta() -> dict:
+    meta: dict = {"labels": ["enhancement"]}
+    in_labels = False
+    label_list: list[str] = []
+    for line in META_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("issue_number:"):
+            meta["issue_number"] = int(line.split(":", 1)[1].strip())
+            in_labels = False
+        elif line.startswith("upstream_repo:"):
+            meta["upstream_repo"] = line.split(":", 1)[1].strip()
+            in_labels = False
+        elif line.startswith("title:"):
+            raw = line.split(":", 1)[1].strip()
+            meta["title"] = raw.strip('"').strip("'")
+            in_labels = False
+        elif line.startswith("labels:"):
+            in_labels = True
+            label_list = []
+        elif in_labels and line.startswith("- "):
+            label_list.append(line[2:].strip())
+    if label_list:
+        meta["labels"] = label_list
+    return meta
+
+
+def issue_url(meta: dict) -> str:
+    repo = meta.get("upstream_repo", "dannerph/homeassistant-eon-energiemonitor")
+    num = meta.get("issue_number")
+    if num:
+        return f"https://github.com/{repo}/issues/{num}"
+    return f"https://github.com/{repo}/issues/new"
+
+
+def main() -> None:
+    meta = load_meta()
+    title = meta.get("title", "Feature: Multiple EON regions via optional `scope` list")
+    body = TEMPLATE_PATH.read_text(encoding="utf-8").strip()
+    url = issue_url(meta)
+    repo = meta.get("upstream_repo", "dannerph/homeassistant-eon-energiemonitor")
+    issue_no = meta.get("issue_number", "?")
+    labels = meta.get("labels") or ["enhancement"]
+    label_str = ", ".join(f"`{l}`" for l in labels)
+
+    header = f"""# GitHub issue (upstream)
+
+| | |
+|---|---|
+| **Title** | {title} |
+| **Repository** | `{repo}` |
+| **Issue** | [#{issue_no}]({url}) |
+| **Labels** | {label_str} |
+| **Spec** | [SCOPE_SPEC.md](SCOPE_SPEC.md) |
+| **Regenerate** | `python3 scripts/generate-scope-issue.py` |
+
+> Auto-generated from `doc/scope-issue.meta.yaml` and `doc/templates/scope-issue.en.md`.  
+> Edit those sources, then run the script. Use **Issue body** below for GitHub (or use `--body-file doc/templates/scope-issue.en.md`).
+
+---
+
+## Issue body (copy from here)
+
+"""
+    footer = f"""
+---
+
+## Recreate or update on GitHub
+
+```bash
+gh issue view {issue_no} --repo {repo}
+
+# New issue:
+gh issue create --repo {repo} \\
+  --title '{title}' \\
+  --body-file doc/templates/scope-issue.en.md \\
+  --label enhancement
+
+# Update existing issue #{issue_no}:
+gh issue edit {issue_no} --repo {repo} \\
+  --title '{title}' \\
+  --body-file doc/templates/scope-issue.en.md
+```
+
+After creating a new issue, set `issue_number` in `doc/scope-issue.meta.yaml` and re-run this script.
+"""
+
+    OUT_PATH.write_text(header + body + footer, encoding="utf-8")
+    print(f"Wrote {OUT_PATH}")
+    print(f"Upstream issue: {url}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Documentation-only PR for the proposed **v0.3.0** feature (multiple EON regions via optional `scope` list). Relates to **#4**. No integration code, no `doc/API.md` changes.

**EON API reference** is in PR #3 (`doc/API.md`, `doc/REGIONEN.md`).

## Added

- **`doc/SCOPE_SPEC.md`** — technical specification (config, entities, validation, repairs)
- **`doc/SCOPE_ISSUE.md`** — generated overview + issue body (run script to refresh)
- **`doc/scope-issue.meta.yaml`** + **`doc/templates/scope-issue.en.md`**
- **`scripts/generate-scope-issue.py`**

## Regenerate issue text

```bash
python3 scripts/generate-scope-issue.py
gh issue edit 4 --repo dannerph/homeassistant-eon-energiemonitor \
  --body-file doc/templates/scope-issue.en.md
```

## Test plan

- [ ] Read `doc/SCOPE_SPEC.md` for consistency with #4
- [ ] Run `python3 scripts/generate-scope-issue.py`